### PR TITLE
Prevent browser overflow

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -24,6 +24,7 @@ body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	line-height: 1;
+	overflow: hidden;
 }
 
 .demo-1 {


### PR DESCRIPTION
Add overflow: hidden to body in order to prevent overflow when dragging the image to the edge of the window

![Screenshot 2020-02-07 18 45 00](https://user-images.githubusercontent.com/5519684/74048417-d4cb1a80-49da-11ea-9b3c-858e185f005b.png)